### PR TITLE
changed v2 to main

### DIFF
--- a/recipes-containers/docker-compose/docker-compose_git.bb
+++ b/recipes-containers/docker-compose/docker-compose_git.bb
@@ -11,7 +11,7 @@ DEPENDS = " \
 SRCREV_FORMAT="compose_survey"
 SRCREV_compose = "02ad467f89ebc343aa03ce89d18875ea4d604ea3"
 
-SRC_URI = "git://github.com/docker/compose;name=compose;branch=v2;protocol=https"
+SRC_URI = "git://github.com/docker/compose;name=compose;branch=main;protocol=https"
 
 include src_uri.inc
 
@@ -27,7 +27,7 @@ GO_IMPORT = "import"
 
 PV = "v2.17.2"
 
-COMPOSE_PKG = "github.com/docker/compose/v2"
+COMPOSE_PKG = "github.com/docker/compose/"
 
 inherit go goarch
 inherit pkgconfig


### PR DESCRIPTION
# Problem

My Yocto build kept breaking because my build could not fetch Docker Compose resources from the `v2` branch. Upon further investigation, the docker compose `v2` branch does not exist anymore. The `v2` branch was most likely merged with `main` branch.

# Solution

Edited `docker-compose_git.bb` to point to the **main** branch of the docker compose repo. This fixed my yocto build.

I would like this PR to be reviewed and accepted if possible.