### PR TITLE
Update SRCREV to match podman-compose v1.0.6

### DIFF
--- a/recipes-containers/podman-compose/podman-compose_1.0.6.bb
+++ b/recipes-containers/podman-compose/podman-compose_1.0.6.bb
@@ -6,7 +6,7 @@ inherit setuptools3
 
 SRC_URI = "git://github.com/containers/podman-compose.git;branch=stable;protocol=https"
 
-SRCREV = "24ec539932580a6bc96d6eb2341141b6d7198b39"
+SRCREV = "f6dbce36181c44d0d08b6f4ca166508542875ce1"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
The `SRCREV` in the 1.0.6 `podman-compose` recipe currently points to the v1.0.3 release of `github.com/containers/podman-compose` stable branch. This change updates the `SRCREV` to instead point to the latest commit on that repo's stable branch, which is also their 1.0.6 tag.

Tested by updating my Yocto build to point to my forked branch.  Running `podman-compose --version` on my target hardware showed that I am now running v1.0.6.

Reference Issue #8 
