### PR TITLE
docker.inc: Set cgroup driver to systemd in docker.service for system…

### DIFF
--- a/recipes-containers/docker/docker.inc
+++ b/recipes-containers/docker/docker.inc
@@ -107,6 +107,7 @@ do_install() {
 		install -m 644 ${S}/src/import/contrib/init/systemd/docker.* ${D}/${systemd_unitdir}/system
 		# replaces one copied from above with one that uses the local registry for a mirror
 		install -m 644 ${S}/src/import/contrib/init/systemd/docker.service ${D}/${systemd_unitdir}/system
+                sed -i 's|ExecStart=/usr/bin/dockerd -H fd://|ExecStart=/usr/bin/dockerd  --exec-opt native.cgroupdriver=systemd  -H fd://|' ${D}/${systemd_unitdir}/system/docker.service
 		rm -f ${D}/${systemd_unitdir}/system/docker.service.rpm
 	else
 		install -d ${D}${sysconfdir}/init.d


### PR DESCRIPTION
…d based systems

cgroupfs driver is not recommended when systemd is the init system because systemd expects a single cgroup manager on the system. Violating the recommendation will have an impact while using Kubernetes.

This change sets cgroup driver to systemd in docker.service for systems whose init system is systemd.